### PR TITLE
Adding node group and processing for node groups

### DIFF
--- a/pkg/ci-firewall/cli/toolkit/nodefile/addnode.go
+++ b/pkg/ci-firewall/cli/toolkit/nodefile/addnode.go
@@ -20,6 +20,7 @@ type NodeFileAddNodeOptions struct {
 	password string
 	privatekeyfile string
 	tags []string
+	group string
 }
 
 func newNodeFileAddNodeOptions() *NodeFileAddNodeOptions {
@@ -53,7 +54,7 @@ func (nfano *NodeFileAddNodeOptions) Validate() (err error) {
 }
 
 func (nfano *NodeFileAddNodeOptions) Run() (err error) {
-	err = node.AddNodeToFile(nfano.nodefile, nfano.name, nfano.user, nfano.address, nfano.baseos, nfano.arch, nfano.password, nfano.privatekeyfile, nfano.tags, nfano.port)
+	err = node.AddNodeToFile(nfano.nodefile, nfano.name, nfano.user, nfano.address, nfano.baseos, nfano.arch, nfano.password, nfano.privatekeyfile, nfano.tags, nfano.port, nfano.group)
 	if err != nil {
 		return fmt.Errorf("failed to add node info to file : %w", err)
 	}
@@ -80,5 +81,6 @@ func NewCmdNodeFileAddNode(name, fullname string) *cobra.Command {
 	cmd.Flags().StringVar(&o.password, "password", "", "The password to use to login to node")
 	cmd.Flags().StringVar(&o.privatekeyfile, "privatekeyfile", "", "The path to the private key file")
 	cmd.Flags().StringArrayVar(&o.tags, "tag", []string{}, "The tags to add to the node")
+	cmd.Flags().StringVar(&o.group, "group", "", "the group to which the machine belongs. Defaults to \"\"")
 	return cmd
 }

--- a/pkg/ci-firewall/cli/worker/work.go
+++ b/pkg/ci-firewall/cli/worker/work.go
@@ -145,7 +145,7 @@ func (wo *WorkOptions) Validate() (err error) {
 	if wo.retryLoopCount < 1 {
 		return fmt.Errorf("retry count should be a natural number i.e >= 1")
 	}
-	if wo.processNodeGroup != "" || wo.processNodeGroup != node.NodeGroupRandomOnePerGroup {
+	if wo.processNodeGroup != "" && wo.processNodeGroup != node.NodeGroupRandomOnePerGroup {
 		return fmt.Errorf("processnode group must be one of following : %v", []string{node.NodeGroupRandomOnePerGroup})
 	}
 	return nil


### PR DESCRIPTION
This PR adds a node group field `Group` to the node file, updating parameters as needed. The default group is `""` i.e no name/anonymous group.
It also adds functionality to optionally process nodes based on their group using the `--processnodegroup` flag to `ci-firewall work`, which defauls to `""` empty string i.e no need to process the node groups.
The only other option currently is `random-one-per-group` which tells ci-firewall to pre-process node list from the node files, selecting one node per group randomly into the final node list

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>